### PR TITLE
Add missing dependency: react-addons-css-transition-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-react": "^5.0.1",
     "expect": "^1.18.0",
     "react": "^0.14.7",
+    "react-addons-css-transition-group": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.14.1"


### PR DESCRIPTION
``` plain
     "react": "^0.14.7",
+    "react-addons-css-transition-group": "^0.14.7",
     "react-dom": "^0.14.7",
```
